### PR TITLE
Correct some packaging problems

### DIFF
--- a/poor_smime_sign/__init__.py
+++ b/poor_smime_sign/__init__.py
@@ -6,4 +6,4 @@ __all__ = ['smime_sign', 'smime_verify']
 
 __author__ = 'Julius Seporaitis'
 __email__ = 'julius@seporaitis.net'
-__version__ = '1.0.0'
+__version__ = '2.0.3'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,3 @@
-bumpversion==0.5.3
-wheel==0.23.0
 watchdog==0.8.3
 flake8==2.4.1
 tox==2.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,2 @@
-[bumpversion]
-current_version = 1.0.0
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-
-[bumpversion:file:poor-smime-sign/__init__.py]
-
-[wheel]
+[bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+import os
+import re
 
 from setuptools import setup
 
+
+def get_version(package):
+    """
+    Return package version as listed in `__version__` in `init.py`.
+    """
+    init_py = open(os.path.join(package, '__init__.py')).read()
+    return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
+
+
+version = get_version('poor_smime_sign')
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
-
-requirements = [
-    # TODO: put package requirements here
-]
-
-test_requirements = [
-    # TODO: put package test requirements here
-]
 
 setup(
     name='poor-smime-sign',
@@ -33,7 +36,7 @@ setup(
     package_dir={'poor_smime_sign':
                  'poor_smime_sign'},
     include_package_data=True,
-    install_requires=requirements,
+    install_requires=[],
     license="MIT",
     zip_safe=False,
     keywords='smime sign passbook',
@@ -49,5 +52,5 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     test_suite='tests',
-    tests_require=test_requirements
+    tests_require=[]
 )


### PR DESCRIPTION
- Use version from `__init__.py` directly in `setup.py`, avoiding import in case dependencies aren't there
- Remove `bumpversion` which isn't being used
- `wheel` no longer needed in requirements as `pip` installs it
- `bdist_wheel` is the non-deprecated header for the section in `setup.cfg`
- Remove `TODO` lists for requirements in `setup.py`
